### PR TITLE
Bump InvMenu version

### DIFF
--- a/.poggit.yml
+++ b/.poggit.yml
@@ -8,5 +8,5 @@ projects:
     libs:
       - src: muqsit/InvMenu/InvMenu
         branch: master
-        version: ^4.1.0
+        version: ^4.1.1
 ...

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 name: PlayerTrade
 author: alvin0319
 main: alvin0319\PlayerTrade\PlayerTrade
-version: 1.0.1
+version: 1.0.2
 api: 3.0.0
 description: A PocketMine-MP plugin that implements trade like PC server!
 


### PR DESCRIPTION
I have an issue when a player joins the game
`Error: Class 'Ds\Queue' not found
File: plugins/PlayerTrade.phar/src/alvin0319/PlayerTrade/libs/muqsit/invmenu/session/PlayerNetwork
Line: 52
Type: Error`

Muqsit solved that issue in InvMenu version 4.1.1, https://github.com/Muqsit/InvMenu/commit/af247cf4b5d43b72c5a3fff74d13898bcf118cb1